### PR TITLE
Fix: solved problem with guard and toast global state

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Providers } from "./providers";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import { Toaster } from 'react-hot-toast'
-import { useEffect } from 'react'
+import FlashToastEffect from "@/components/layout/flash-toast-effect";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -27,6 +27,7 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} h-full`}>
       <body className={`${inter.className} h-full bg-white`}>
         <Providers>
+          <FlashToastEffect />
           <div className="min-h-full">
             <Navbar />
             <main className="pt-16">

--- a/src/components/guards/WalletGuard.tsx
+++ b/src/components/guards/WalletGuard.tsx
@@ -1,30 +1,25 @@
-'use client'
+'use client';
+import { useEffect } from 'react';
+import { useAccount } from 'wagmi';
+import { useRouter, usePathname } from 'next/navigation';
+import { useFlashToast } from '@/store/flashToastStore';
 
-import { useAccount } from 'wagmi'
-import { useRouter, usePathname } from 'next/navigation'
-import { useEffect } from 'react'
-import { toast } from 'react-hot-toast'
-
-interface WalletGuardProps {
-  children: React.ReactNode
-}
-
-export function WalletGuard({ children }: WalletGuardProps) {
-  const { isConnected } = useAccount()
-  const router = useRouter()
-  const pathname = usePathname()
+export function WalletGuard({ children }: { children: React.ReactNode }) {
+  const { isConnected } = useAccount();
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!isConnected) {
-      const pageName = pathname.split('/').pop() || 'this page'
-      toast.error(`Please connect your wallet to access ${pageName}`)
-      router.replace('/')
+      const pageName = pathname.split('/').pop() || 'this page';
+      // save the message globally
+      useFlashToast.getState().set(
+        `Please connect your wallet to access “${pageName}”`,
+        'error'
+      );
+      router.back();
     }
-  }, [isConnected, router, pathname])
+  }, [isConnected, pathname, router]);
 
-  if (!isConnected) {
-    return null
-  }
-
-  return <>{children}</>
-} 
+  return isConnected ? <>{children}</> : null;
+}

--- a/src/components/layout/flash-toast-effect.tsx
+++ b/src/components/layout/flash-toast-effect.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+import { useFlashToast } from '@/store/flashToastStore';
+
+export default function FlashToastEffect() {
+  const { message, kind, clear } = useFlashToast();
+
+  useEffect(() => {
+    if (message) {
+      toast[kind](message);
+      clear();
+    }
+  }, [message, kind, clear]);
+
+  return null;
+}

--- a/src/store/flashToastStore.ts
+++ b/src/store/flashToastStore.ts
@@ -1,0 +1,16 @@
+// lib/flashToastStore.ts
+import { create } from 'zustand';
+
+type ToastKind = 'success' | 'error' | 'loading';
+
+export const useFlashToast = create<{
+  message: string | null;
+  kind: ToastKind;
+  set: (msg: string, k?: ToastKind) => void;
+  clear: () => void;
+}>((set) => ({
+  message: null,
+  kind: 'error',
+  set: (message, kind = 'error') => set({ message, kind }),
+  clear: () => set({ message: null }),
+}));


### PR DESCRIPTION
This pull request introduces a new global flash toast mechanism to improve user feedback and refactors the `WalletGuard` component to utilize this mechanism. Additionally, it simplifies the `RootLayout` structure by integrating the flash toast effect.

### Flash Toast Mechanism:

* **`src/store/flashToastStore.ts`**: Added a Zustand store (`useFlashToast`) to manage global flash toast messages, including their type (`success`, `error`, or `loading`) and lifecycle (set/clear).
* **`src/components/layout/flash-toast-effect.tsx`**: Created a new `FlashToastEffect` component that listens to the flash toast store and displays a toast message using `react-hot-toast`. The message is cleared after being shown.

### Refactor of `WalletGuard`:

* **`src/components/guards/WalletGuard.tsx`**: Updated the `WalletGuard` component to use the new flash toast store for displaying error messages when the wallet is not connected. This replaces the previous inline toast logic with a more centralized approach.

### Integration into `RootLayout`:

* **`src/app/layout.tsx`**: Imported and integrated the `FlashToastEffect` component into the `RootLayout`, ensuring the flash toast mechanism is globally accessible across the application. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L9-R9) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R30)